### PR TITLE
fix: remove direct byte comparison

### DIFF
--- a/src/Encoding/Base58BtcVarTime.php
+++ b/src/Encoding/Base58BtcVarTime.php
@@ -67,11 +67,12 @@ class Base58BtcVarTime
             ++$begin;
         }
 
-        // This leaks some information about $baseValue at each position evaluated
         $baseEncodingPosition = 0;
-        /** @psalm-suppress InvalidArrayOffset */
-        while ($baseEncodingPosition !== $size && $baseValue[$baseEncodingPosition] === 0) {
-            ++$baseEncodingPosition;
+        $flag = 1;
+        for ($i = 0; $i < $size; ++$i) {
+            /** @psalm-suppress InvalidArrayOffset */
+            $flag = (($baseValue[$i] - 1) >> 8) & $flag;
+            $baseEncodingPosition += $flag;
         }
 
         // 0x31 is the encoded representation of zero
@@ -95,6 +96,7 @@ class Base58BtcVarTime
         $flag = 1;
         $acc = 0;
         for ($i = 0; $i < $sourceLength; ++$i) {
+            // $flag &= (int)($flag === 0x31); without bool-to-int leakage
             $flag = ((($source[$i] ^ 0x31) - 1) >> 8) & $flag;
             $acc += $flag;
         }
@@ -126,9 +128,11 @@ class Base58BtcVarTime
         }
 
         $decodedOffset = 0;
-        /** @psalm-suppress InvalidArrayOffset */
-        while ($decodedOffset !== $size && $decodedBytes[$decodedOffset] === 0) {
-            ++$decodedOffset;
+        $flag = 1;
+        for ($i = 0; $i < $size; ++$i) {
+            /** @psalm-suppress InvalidArrayOffset */
+            $flag = (($decodedBytes[$i] - 1) >> 8) & $flag;
+            $decodedOffset += $flag;
         }
 
         $finalBytes = array_fill(

--- a/tests/Encoding/Base58BtcVarTimeTest.php
+++ b/tests/Encoding/Base58BtcVarTimeTest.php
@@ -18,7 +18,6 @@ class Base58BtcVarTimeTest extends TestCase
      */
     public function testDiv58(): void
     {
-        $this->markTestSkipped('test');
         for ($x = 0; $x < 32768; ++$x) {
             $expectedDiv = intdiv($x, 58);
             $expectedMod = $x % 58;
@@ -58,7 +57,6 @@ class Base58BtcVarTimeTest extends TestCase
 
     public function testEncodeDecodeByte(): void
     {
-        $this->markTestSkipped('test');
         $alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
         $input = range(0, 57);
         $str = '';
@@ -75,7 +73,6 @@ class Base58BtcVarTimeTest extends TestCase
     }
     public function testEncodeDecode(): void
     {
-        $this->markTestSkipped('test');
         for ($i = 1; $i < 100; ++$i) {
             $random = random_bytes($i);
             $encoded = Base58BtcVarTime::encode($random);


### PR DESCRIPTION
This further hardens the base58 codec from side-channels. See #11 for the overarching goal of this work.

With this commit, the only thing that still leaks is:

1. The number of leading zeroes (encoding) / 0x31 (decoding)
2. Input lengths (not sensitive, especially for fixed-length secrets such as Ed25519 secret keys)
3. Output lengths (not sensitive, ditto)

The number of leading zeroes might be sensitive, if you have (by sheer coincidence) leading zeroes in your randomly-generated secret. This is possible for Ed25519: The clamping on the first byte is only an AND mask, so `0x00` is a valid first byte for any key.