### PR TITLE
feat!: force canonicalization of Actor IDs

### DIFF
--- a/src/Protocol/Actions/AddAuxData.php
+++ b/src/Protocol/Actions/AddAuxData.php
@@ -5,6 +5,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedActions\EncryptedAddAuxData;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedProtocolMessageInterface;
@@ -23,9 +24,14 @@ class AddAuxData implements ProtocolMessageInterface, JsonSerializable
     private ?string $auxId;
     private DateTimeImmutable $time;
 
-    public function __construct(string $actor, string $auxType, string $auxData, ?string $auxId = null, ?DateTimeInterface $time = null)
-    {
-        $this->actor = $actor;
+    public function __construct(
+        string $actor,
+        string $auxType,
+        string $auxData,
+        ?string $auxId = null,
+        ?DateTimeInterface $time = null
+    ) {
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         $this->auxType = $auxType;
         $this->auxData = $auxData;
         $this->auxId = $auxId;

--- a/src/Protocol/Actions/AddKey.php
+++ b/src/Protocol/Actions/AddKey.php
@@ -4,6 +4,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\ProtocolMessageInterface;
 use FediE2EE\PKD\Crypto\PublicKey;
@@ -24,7 +25,7 @@ class AddKey implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $actor, PublicKey $publicKey, ?DateTimeInterface $time = null)
     {
-        $this->actor = $actor;
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         $this->publicKey = $publicKey;
         if (is_null($time)) {
             $time = new DateTimeImmutable('NOW');

--- a/src/Protocol/Actions/BurnDown.php
+++ b/src/Protocol/Actions/BurnDown.php
@@ -5,6 +5,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedActions\EncryptedBurnDown;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedProtocolMessageInterface;
@@ -24,7 +25,7 @@ class BurnDown implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $actor, string $operator, ?DateTimeInterface $time = null, ?string $otp = null)
     {
-        $this->actor = $actor;
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         $this->operator = $operator;
         if (is_null($time)) {
             $time = new DateTimeImmutable('NOW');

--- a/src/Protocol/Actions/Fireproof.php
+++ b/src/Protocol/Actions/Fireproof.php
@@ -5,6 +5,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedActions\EncryptedFireproof;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedProtocolMessageInterface;
@@ -22,7 +23,7 @@ class Fireproof implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $actor, ?DateTimeInterface $time = null)
     {
-        $this->actor = $actor;
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         if (is_null($time)) {
             $time = new DateTimeImmutable('NOW');
         }

--- a/src/Protocol/Actions/MoveIdentity.php
+++ b/src/Protocol/Actions/MoveIdentity.php
@@ -5,6 +5,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedActions\EncryptedMoveIdentity;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedProtocolMessageInterface;
@@ -23,8 +24,8 @@ class MoveIdentity implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $oldActor, string $newActor, ?DateTimeInterface $time = null)
     {
-        $this->oldActor = $oldActor;
-        $this->newActor = $newActor;
+        $this->oldActor = Handler::getWebFinger()->canonicalize($oldActor);
+        $this->newActor = Handler::getWebFinger()->canonicalize($newActor);
         if (is_null($time)) {
             $time = new DateTimeImmutable('NOW');
         }

--- a/src/Protocol/Actions/RevokeAuxData.php
+++ b/src/Protocol/Actions/RevokeAuxData.php
@@ -5,6 +5,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedActions\EncryptedRevokeAuxData;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedProtocolMessageInterface;
@@ -25,7 +26,7 @@ class RevokeAuxData implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $actor, string $auxType, ?string $auxData = null, ?string $auxId = null, ?DateTimeInterface $time = null)
     {
-        $this->actor = $actor;
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         $this->auxType = $auxType;
         $this->auxData = $auxData;
         $this->auxId = $auxId;

--- a/src/Protocol/Actions/RevokeKey.php
+++ b/src/Protocol/Actions/RevokeKey.php
@@ -4,6 +4,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\ProtocolMessageInterface;
 use FediE2EE\PKD\Crypto\PublicKey;
@@ -24,7 +25,7 @@ class RevokeKey implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $actor, PublicKey $publicKey, ?DateTimeInterface $time = null)
     {
-        $this->actor = $actor;
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         $this->publicKey = $publicKey;
         if (is_null($time)) {
             $time = new DateTimeImmutable('NOW');

--- a/src/Protocol/Actions/UndoFireproof.php
+++ b/src/Protocol/Actions/UndoFireproof.php
@@ -5,6 +5,7 @@ namespace FediE2EE\PKD\Crypto\Protocol\Actions;
 use DateTimeImmutable;
 use DateTimeInterface;
 use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\ToStringTrait;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedActions\EncryptedUndoFireproof;
 use FediE2EE\PKD\Crypto\Protocol\EncryptedProtocolMessageInterface;
@@ -22,7 +23,7 @@ class UndoFireproof implements ProtocolMessageInterface, JsonSerializable
 
     public function __construct(string $actor, ?DateTimeInterface $time = null)
     {
-        $this->actor = $actor;
+        $this->actor = Handler::getWebFinger()->canonicalize($actor);
         if (is_null($time)) {
             $time = new DateTimeImmutable('NOW');
         }

--- a/src/Protocol/Handler.php
+++ b/src/Protocol/Handler.php
@@ -9,10 +9,7 @@ use FediE2EE\PKD\Crypto\Exceptions\{
     JsonException,
     NotImplementedException
 };
-use FediE2EE\PKD\Crypto\{
-    SecretKey,
-    UtilTrait
-};
+use FediE2EE\PKD\Crypto\{ActivityPub\WebFinger, SecretKey, UtilTrait};
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use ParagonIE\HPKE\{
     HPKE,
@@ -24,6 +21,15 @@ use SodiumException;
 class Handler
 {
     use UtilTrait;
+    public static ?WebFinger $wf = null;
+
+    public static function getWebFinger(): WebFinger
+    {
+        if (is_null(self::$wf)) {
+            self::$wf = new WebFinger();
+        }
+        return self::$wf;
+    }
 
     /**
      * @throws CryptoException

--- a/tests/Protocol/HandlerTest.php
+++ b/tests/Protocol/HandlerTest.php
@@ -32,7 +32,7 @@ class HandlerTest extends TestCase
         $keyMap->addKey('foo', new SymmetricKey(random_bytes(32)));
 
         $addKey = new AddKey(
-            'test-actor',
+            'fedie2ee@mastodon.social',
             $publicKey
         );
         $encryptedAddKey = $addKey->encrypt($keyMap);
@@ -59,7 +59,7 @@ class HandlerTest extends TestCase
         $keyMap->addKey('foo', new SymmetricKey(random_bytes(32)));
 
         $addKey = new AddKey(
-            'test-actor',
+            'fedie2ee@mastodon.social',
             $publicKey
         );
         $encryptedAddKey = $addKey->encrypt($keyMap);
@@ -86,7 +86,7 @@ class HandlerTest extends TestCase
         $keyMap->addKey('foo', new SymmetricKey(random_bytes(32)));
 
         $addKey = new AddKey(
-            'test-actor',
+            'fedie2ee@mastodon.social',
             $publicKey
         );
         $encryptedAddKey = $addKey->encrypt($keyMap);
@@ -108,7 +108,7 @@ class HandlerTest extends TestCase
 
         // Create an inaugural AddKey message
         $message = new AddKey(
-            actor: "https://example.com/@actor",
+            actor: "fedie2ee@mastodon.social",
             publicKey: $publicKey
         );
 
@@ -141,7 +141,7 @@ class HandlerTest extends TestCase
 
         // Create an inaugural AddKey message
         $message = new AddKey(
-            actor: "https://example.com/@actor",
+            actor: "fedie2ee@mastodon.social",
             publicKey: $publicKey
         );
 

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -57,7 +57,7 @@ class ParserTest extends TestCase
         $keyMap->addKey('foo', new SymmetricKey(random_bytes(32)));
 
         $addKey = new AddKey(
-            'test-actor',
+            'fedie2ee@mastodon.social',
             $publicKey
         );
         $encryptedAddKey = $addKey->encrypt($keyMap);
@@ -87,7 +87,7 @@ class ParserTest extends TestCase
 
         // Create an inaugural AddKey message
         $message = new AddKey(
-            actor: "https://example.com/@actor",
+            actor: "fedie2ee@mastodon.social",
             publicKey: $publicKey
         );
 


### PR DESCRIPTION
This will ensure all Actor IDs are consistent when using this library.

I also added caching so our unit tests don't create a lot of unnecessary traffic.