### PR TITLE
feat: HPKEAdapter::isHpkeCiphertext()

### DIFF
--- a/src/Protocol/HPKEAdapter.php
+++ b/src/Protocol/HPKEAdapter.php
@@ -21,6 +21,21 @@ class HPKEAdapter
     ) {}
 
     /**
+     * @api
+     */
+    public function isHpkeCiphertext(string $message): bool
+    {
+        if (strlen($message) < 5) {
+            return false;
+        }
+        $header = substr($message, 0, 5);
+        if (!hash_equals($header, self::HPKE_PREFIX)) {
+            return false;
+        }
+        return preg_match('#^[A-Za-z0-9-_]+$#', substr($message, 5)) === 1;
+    }
+
+    /**
      * @throws HPKEException
      */
     public function open(

--- a/tests/Protocol/HPKETest.php
+++ b/tests/Protocol/HPKETest.php
@@ -14,18 +14,21 @@ use FediE2EE\PKD\Crypto\Exceptions\{
     JsonException,
     NotImplementedException
 };
-use FediE2EE\PKD\Crypto\Protocol\{Actions\AddKey,
+use FediE2EE\PKD\Crypto\Protocol\{
+    Actions\AddKey,
     EncryptedProtocolMessageInterface,
     Handler,
     HPKEAdapter,
-    Parser,
-    ProtocolMessageInterface};
-use ParagonIE\HPKE\{Factory,
+    Parser
+};
+use ParagonIE\HPKE\{
+    Factory,
     HPKE,
     HPKEException,
     Interfaces\DecapsKeyInterface,
     Interfaces\EncapsKeyInterface,
-    KEM\DHKEM\DecapsKey};
+    KEM\DHKEM\DecapsKey
+};
 use PHPUnit\Framework\Attributes\{
     CoversClass,
     DataProvider
@@ -91,6 +94,7 @@ class HPKETest extends TestCase
         $bundle = $handler->handle($dummy->encrypt($keyMap), $sk, $keyMap, $root);
         $encrypted = $handler->hpkeEncrypt($bundle, $encapsKey, $ciphersuite);
         $this->assertIsString($encrypted);
+        $this->assertTrue((new HPKEAdapter($ciphersuite))->isHpkeCiphertext($encrypted));
 
         // HPKE decryption!
         $parser = new Parser();


### PR DESCRIPTION
This is a quick method for checking if a string is HPKE encrypted according to our spec.