### PR TITLE
feat: AttributeKeyMap::addRandomKey

### DIFF
--- a/src/AttributeEncryption/AttributeKeyMap.php
+++ b/src/AttributeEncryption/AttributeKeyMap.php
@@ -15,6 +15,12 @@ class AttributeKeyMap
         return $this;
     }
 
+    public function addRandomKey(string $attribute): self
+    {
+        $this->keys[$attribute] = SymmetricKey::generate();
+        return $this;
+    }
+
     public function getKey(string $attribute): ?SymmetricKey
     {
         return $this->keys[$attribute] ?? null;

--- a/tests/AttributeEncryption/AttributeKeyMapTest.php
+++ b/tests/AttributeEncryption/AttributeKeyMapTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+namespace FediE2EE\PKD\Crypto\Tests\AttributeEncryption;
+
+use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
+use FediE2EE\PKD\Crypto\SymmetricKey;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AttributeKeyMap::class)]
+class AttributeKeyMapTest extends TestCase
+{
+    public function testAddKey(): void
+    {
+        $keyMap = new AttributeKeyMap();
+        $blah = str_repeat("\xff", 32);
+        $keyMap->addKey('foo', new SymmetricKey($blah));
+        $this->assertTrue($keyMap->hasKey('foo'));
+        $this->assertFalse($keyMap->hasKey('bar'));
+        $this->assertSame(['foo'], $keyMap->getAttributes());
+        $got = $keyMap->getKey('foo');
+        $this->assertInstanceOf(SymmetricKey::class, $got);
+        $this->assertSame($blah, $got->getBytes());
+
+        $keyMap->addRandomKey('baz');
+        $this->assertTrue($keyMap->hasKey('baz'));
+        $baz = $keyMap->getKey('baz');
+        $this->assertNotSame($blah, $baz->getBytes());
+    }
+}


### PR DESCRIPTION
To reduce boilerplate (since, most of the time, you want a random key here *anyway*).