### PR TITLE
fix!: don't double-encode merkle roots

### DIFF
--- a/src/Protocol/Bundle.php
+++ b/src/Protocol/Bundle.php
@@ -46,7 +46,7 @@ class Bundle
         return new self(
             $data['action'],
             $data['message'],
-            Base64UrlSafe::decodeNoPadding($data['recent-merkle-root']),
+            $data['recent-merkle-root'],
             Base64UrlSafe::decodeNoPadding($data['signature']),
             $symmetricKeys
         );
@@ -76,7 +76,7 @@ class Bundle
             'message' =>
                 $this->message,
             'recent-merkle-root' =>
-                Base64UrlSafe::encodeUnpadded($this->recentMerkleRoot),
+                $this->recentMerkleRoot,
             'signature' =>
                 Base64UrlSafe::encodeUnpadded($this->signature),
             'symmetric-keys' =>

--- a/tests/Protocol/HandlerTest.php
+++ b/tests/Protocol/HandlerTest.php
@@ -7,6 +7,7 @@ use FediE2EE\PKD\Crypto\AttributeEncryption\AttributeKeyMap;
 use FediE2EE\PKD\Crypto\Exceptions\CryptoException;
 use FediE2EE\PKD\Crypto\Exceptions\JsonException;
 use FediE2EE\PKD\Crypto\Exceptions\NotImplementedException;
+use FediE2EE\PKD\Crypto\Merkle\Tree;
 use FediE2EE\PKD\Crypto\Protocol\Actions\AddKey;
 use FediE2EE\PKD\Crypto\Protocol\Handler;
 use FediE2EE\PKD\Crypto\Protocol\Bundle;
@@ -117,7 +118,7 @@ class HandlerTest extends TestCase
             ->addKey('actor', SymmetricKey::generate())
             ->addKey('public-key', SymmetricKey::generate());
 
-        $merkleRoot = random_bytes(32);
+        $merkleRoot = (new Tree([random_bytes(32)]))->getEncodedRoot();
 
         $handler = new Handler();
         $bundle = $handler->handle($message, $secretKey, $keyMap, $merkleRoot);
@@ -150,7 +151,7 @@ class HandlerTest extends TestCase
             ->addKey('actor', SymmetricKey::generate())
             ->addKey('public-key', SymmetricKey::generate());
 
-        $merkleRoot = random_bytes(32);
+        $merkleRoot = (new Tree([random_bytes(32)]))->getEncodedRoot();
 
         $handler = new Handler();
         $bundle = $handler->handle($message, $secretKey, $keyMap, $merkleRoot);

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -17,11 +17,7 @@ use FediE2EE\PKD\Crypto\Protocol\{
     Parser,
 };
 use ParagonIE\ConstantTime\Base64UrlSafe;
-use FediE2EE\PKD\Crypto\{
-    PublicKey,
-    SecretKey,
-    SymmetricKey
-};
+use FediE2EE\PKD\Crypto\{Merkle\Tree, PublicKey, SecretKey, SymmetricKey};
 use ParagonIE\HPKE\{
     Factory,
     HPKEException,
@@ -96,7 +92,7 @@ class ParserTest extends TestCase
             ->addKey('actor', SymmetricKey::generate())
             ->addKey('public-key', SymmetricKey::generate());
 
-        $merkleRoot = random_bytes(32);
+        $merkleRoot = (new Tree([random_bytes(32)]))->getEncodedRoot();
 
         $handler = new Handler();
         $bundle = $handler->handle($message, $secretKey, $keyMap, $merkleRoot);


### PR DESCRIPTION
This is, strictly speaking, a breaking change in how messages are formatted.